### PR TITLE
Update types to reflect project exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,15 +9,10 @@ export interface ApiKeyInfo {
   apiKey: string;
 }
 
-declare class UUIDAPIKey {
-  checkDashes(positions: number[], str: string): boolean;
-  isUUID(uuid: string): boolean;
-  isAPIKey(apiKey: string): boolean;
-  toAPIKey(uuid: string, options?: Partial<UUIDOptions>): string;
-  toUUID(apiKey: string): string;
-  check(apiKey: string, uuid: string): boolean;
-  create(options?: Partial<UUIDOptions>): ApiKeyInfo;
-}
-
-declare let obj: UUIDAPIKey;
-export default obj;
+export function checkDashes(positions: number[], str: string): boolean;
+export function isUUID(uuid: string): boolean;
+export function isAPIKey(apiKey: string): boolean;
+export function toAPIKey(uuid: string, options?: Partial<UUIDOptions>): string;
+export function toUUID(apiKey: string): string;
+export function check(apiKey: string, uuid: string): boolean;
+export function create(options?: Partial<UUIDOptions>): ApiKeyInfo;


### PR DESCRIPTION
Love the project & we're using in our own work. Thank you for creating it.

The types do not appear to reflect how the javascript is exported, however. They aren't exported to a default namespace like the types presently represent. This proposed update is what we used so that the type system resolved the exports correctly.